### PR TITLE
Add tshark packet analysis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This MCP is able to run terminal commands as well as interacting with web applic
 - `John the Ripper`
 - `Metasploit-Framework`
 - `Nikto`
+- `Tshark`
 - `Nmap`
 - `sqlmap`
 - `WPScan`

--- a/client.py
+++ b/client.py
@@ -376,6 +376,45 @@ def setup_mcp_server(kali_client: KaliToolsClient) -> FastMCP:
         }
         return kali_client.safe_post("api/tools/enum4linux", data)
 
+    @mcp.tool(name="tshark_capture")
+    def tshark_capture(
+        interface: str = "",
+        capture_filter: str = "",
+        display_filter: str = "",
+        packet_count: str = "",
+        duration: str = "",
+        read_file: str = "",
+        output_fields: str = "",
+        additional_args: str = ""
+    ) -> Dict[str, Any]:
+        """
+        Execute TShark network packet capture and analysis tool.
+        
+        Args:
+            interface: Network interface to capture on (e.g., eth0, wlan0)
+            capture_filter: BPF capture filter (e.g., "tcp port 80")
+            display_filter: Wireshark display filter (e.g., "http.request")
+            packet_count: Number of packets to capture before stopping
+            duration: Capture duration in seconds
+            read_file: Path to a pcap file to read and analyze instead of live capture
+            output_fields: Comma-separated list of fields to output (e.g., "ip.src,ip.dst,tcp.port")
+            additional_args: Additional TShark arguments
+            
+        Returns:
+            Capture/analysis results
+        """
+        data = {
+            "interface": interface,
+            "capture_filter": capture_filter,
+            "display_filter": display_filter,
+            "packet_count": packet_count,
+            "duration": duration,
+            "read_file": read_file,
+            "output_fields": output_fields,
+            "additional_args": additional_args
+        }
+        return kali_client.safe_post("api/tools/tshark", data)
+
     @mcp.tool(name="server_health")
     def server_health() -> Dict[str, Any]:
         """

--- a/server.py
+++ b/server.py
@@ -519,6 +519,56 @@ def enum4linux():
             "error": f"Server error: {str(e)}"
         }), 500
 
+@app.route("/api/tools/tshark", methods=["POST"])
+def tshark():
+    """Execute tshark with the provided parameters."""
+    try:
+        params = request.json
+        interface = params.get("interface", "")
+        capture_filter = params.get("capture_filter", "")
+        display_filter = params.get("display_filter", "")
+        packet_count = params.get("packet_count", "")
+        duration = params.get("duration", "")
+        read_file = params.get("read_file", "")
+        output_fields = params.get("output_fields", "")
+        additional_args = params.get("additional_args", "")
+
+        command = ["tshark"]
+
+        if read_file:
+            command += ["-r", read_file]
+        elif interface:
+            command += ["-i", interface]
+
+        if capture_filter:
+            command += ["-f", capture_filter]
+
+        if display_filter:
+            command += ["-Y", display_filter]
+
+        if packet_count:
+            command += ["-c", str(packet_count)]
+
+        if duration:
+            command += ["-a", f"duration:{duration}"]
+
+        if output_fields:
+            command += ["-T", "fields"]
+            for field in output_fields.split(","):
+                command += ["-e", field.strip()]
+
+        if additional_args:
+            command += shlex.split(additional_args)
+
+        result = execute_command(command)
+        return jsonify(result)
+    except Exception as e:
+        logger.error(f"Error in tshark endpoint: {str(e)}")
+        logger.error(traceback.format_exc())
+        return jsonify({
+            "error": f"Server error: {str(e)}"
+        }), 500
+
 
 # Health check endpoint
 @app.route("/health", methods=["GET"])


### PR DESCRIPTION
## Description

Adds TShark (Wireshark's CLI) as a new tool to the MCP Kali Server, enabling network packet capture and traffic analysis directly through the MCP agent.

## Changes

- **[server.py](cci:7://file:///e:/Opensource%20Contribution/MCP-Kali-Server/server.py:0:0-0:0)**: Added `/api/tools/tshark` API endpoint
- **[client.py](cci:7://file:///e:/Opensource%20Contribution/MCP-Kali-Server/client.py:0:0-0:0)**: Added [tshark_capture](cci:1://file:///e:/Opensource%20Contribution/MCP-Kali-Server/client.py:378:4-415:62) MCP tool registration

## Supported Parameters

| Parameter | TShark Flag | Description |
|---|---|---|
| `interface` | `-i` | Network interface to capture on (e.g., `eth0`, `wlan0`) |
| `capture_filter` | `-f` | BPF capture filter (e.g., `"tcp port 80"`) |
| `display_filter` | `-Y` | Wireshark display filter (e.g., `"http.request"`) |
| `packet_count` | `-c` | Number of packets to capture before stopping |
| `duration` | `-a duration:N` | Capture duration in seconds |
| `read_file` | `-r` | Read and analyze an existing pcap file |
| `output_fields` | `-T fields -e` | Comma-separated field extraction |
| `additional_args` | — | Any extra TShark arguments |

## Use Cases

- Live packet capture on a specific interface
- Analyzing existing `.pcap` files from other tools
- Filtering traffic by protocol, port, or IP
- Extracting specific fields for structured output

## Testing

Follows the same endpoint pattern and error handling as all existing tools (nmap, gobuster, nikto, etc.).
