### PR TITLE
Refactor command execution for tool status check

### DIFF
--- a/server.py
+++ b/server.py
@@ -530,7 +530,7 @@ def health_check():
     
     for tool in essential_tools:
         try:
-            result = execute_command(["which", tool])
+            result = execute_command(f"which {tool}")
             tools_status[tool] = result["success"]
         except:
             tools_status[tool] = False


### PR DESCRIPTION
**Refactor command execution for tool status check**
The /health endpoint reports all tools as missing even when they are correctly installed. This is caused by a wrong argument type being passed to execute_command() in the health check function.

**Package**
mcp-kali-server version: 0.0~git20260119.bffe9f2

**Steps to Reproduce**
1. Install the mcp-kali-server package
2. Install the essential tools — nmap, gobuster, nikto and dirb
3. Start the server
4. curl http://localhost:5000/health

**Expected Result**
{"all_essential_tools_available":true,"tools_status":{"dirb":true,"gobuster":true,"nikto":true,"nmap":true}}

**Actual Result**
{"all_essential_tools_available":false,"tools_status":{"dirb":false,"gobuster":false,"nikto":false,"nmap":false}}

**Root Cause**
The health check passes a list to execute_command() but the function only accepts a string, causing it to fail silently and return false for every tool even when they are installed.

**Fix**
**Change**:
result = execute_command(["which", tool])

**To**:
result = execute_command(f"which {tool}")